### PR TITLE
fix: gatsby-remark-images missing styles

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -27,6 +27,11 @@ module.exports = {
       resolve: `gatsby-plugin-mdx`,
       options: {
         extensions: ['.mdx', '.md'],
+        // a workaround to solve mdx-remark plugin compat issue
+        // https://github.com/gatsbyjs/gatsby/issues/15486
+        plugins: [
+          `gatsby-remark-images`,
+        ],
         gatsbyRemarkPlugins: [
           {
             resolve: `gatsby-remark-images`,


### PR DESCRIPTION
Hey @hagnerd, thanks for converting the starter to mdx! I used your starter to debug a few mdx issues. <sup>[here](https://github.com/d4rekanguok/gatsby-bug-repro-18266) and [here](https://github.com/d4rekanguok/gatsby-bug-repro-18243)  💪 </sup>

I noticed that gatsby-remark-images didn't work properly.

It turned out a recent patch version of `gatsby-remark-images` does not function properly with `gatsby-plugin-mdx`. The previously inline styling of the image is now moved to `gatsby-ssr` render step, which unfortunately isn't recognized by Gatsby (since `gatsby-plugin-mdx` use `gatsbyRemarkPlugins` instead of `plugins`.)

An accepted workaround <sup>[source](https://github.com/gatsbyjs/gatsby/issues/15486#issuecomment-510153237)</sup> is to add `gatsby-remark-images` to `plugins` options, in addition to `gatsbyRemarkPlugins`.

Until an official solution happens, I thought it'd make sense to add this work around to the starter. Of course only if you think that's a good idea.

Thanks again!