### PR TITLE
Import MDXProvider from @mdx-js/react

### DIFF
--- a/wrap-root-element.js
+++ b/wrap-root-element.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { MDXProvider } from '@mdx-js/tag'
+import { MDXProvider } from '@mdx-js/react'
 import { Code } from './src/components/code'
 import { preToCodeBlock } from 'mdx-utils'
 


### PR DESCRIPTION
Closes https://github.com/hagnerd/gatsby-starter-blog-mdx/issues/18

I faced what seems like the same problem as the person who opened the linked issue, and this is what fixed it for me.

Change inspired by the code here: https://mdxjs.com/advanced/components#mdxprovider