### PR TITLE
Change to using mdx.html instead of body

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -86,7 +86,7 @@ module.exports = {
                   data: edge.node.frontmatter.date,
                   url: site.siteMetadata.siteUrl + edge.node.fields.slug,
                   guid: site.siteMetadata.siteUrl + edge.node.fields.slug,
-                  custom_elements: [{ 'content:encoded': edge.node.body }],
+                  custom_elements: [{ 'content:encoded': edge.node.html }],
                 })
               })
             },
@@ -110,7 +110,7 @@ module.exports = {
                       title
                       date
                     }
-                    body
+                    html
                   }
                 }
               }


### PR DESCRIPTION
Using `mdx.body` returns the content that React renders. Returning this to as HTML content to RSS feed readers does not work. [See current demo](https://gatsby-starter-blog-mdx-demo.netlify.com/rss.xml)

Instead `gatsby-plugin-mdx` includes a field named `html` which is filled only during build. 

To see this output on development, you will have to run:
```
gatsby build && gatsby serve
```
